### PR TITLE
feat: add helper bridge

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -1,5 +1,10 @@
-const { app, BrowserWindow } = require('electron');
+const { app, BrowserWindow, ipcMain } = require('electron');
+const { spawn } = require('child_process');
 const path = require('path');
+const readline = require('readline');
+
+let helper;
+let helperReader;
 
 function createWindow() {
   const win = new BrowserWindow({
@@ -14,6 +19,28 @@ function createWindow() {
 }
 
 app.whenReady().then(() => {
+  helper = spawn('python', [path.join(__dirname, '..', 'helper', 'resolve_helper.py')], {
+    stdio: ['pipe', 'pipe', 'inherit']
+  });
+  helperReader = readline.createInterface({ input: helper.stdout });
+
+  ipcMain.on('helper-request', (event, payload) => {
+    if (!helper) {
+      event.reply('helper-response', { error: 'helper not running' });
+      return;
+    }
+    helper.stdin.write(`${JSON.stringify(payload)}\n`);
+    helperReader.once('line', line => {
+      let response;
+      try {
+        response = JSON.parse(line);
+      } catch (e) {
+        response = { error: 'invalid response' };
+      }
+      event.reply('helper-response', response);
+    });
+  });
+
   createWindow();
 
   app.on('activate', () => {
@@ -24,6 +51,11 @@ app.whenReady().then(() => {
 });
 
 app.on('window-all-closed', () => {
+  if (helper) {
+    helper.kill();
+    helper = null;
+    helperReader && helperReader.close();
+  }
   if (process.platform !== 'darwin') {
     app.quit();
   }

--- a/helper/resolve_helper.py
+++ b/helper/resolve_helper.py
@@ -1,5 +1,27 @@
 from pathlib import Path
+import json
+import sys
+
 
 def resolve_path(*segments):
     """Resolve a filesystem path from the given segments."""
     return str(Path(__file__).resolve().parent.joinpath(*segments))
+
+
+def main():
+    """Read JSON requests from stdin and write responses to stdout."""
+    for line in sys.stdin:
+        try:
+            payload = json.loads(line)
+            segments = payload.get("segments", [])
+            result = resolve_path(*segments)
+            response = {"result": result}
+        except Exception as exc:  # pragma: no cover - best effort error reporting
+            response = {"error": str(exc)}
+        json.dump(response, sys.stdout)
+        sys.stdout.write("\n")
+        sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- bridge main process to Python helper using spawn
- forward helper requests/responses over IPC
- add JSON CLI to helper script for path resolving

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf0dcd498883219ab9eb340aff44bf