### PR TITLE
Expose leaderpass API for helper calls

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -26,16 +26,18 @@ app.whenReady().then(() => {
 
   ipcMain.on('helper-request', (event, payload) => {
     if (!helper) {
-      event.reply('helper-response', { error: 'helper not running' });
+      event.reply('helper-response', { ok: false, error: 'helper not running' });
       return;
     }
-    helper.stdin.write(`${JSON.stringify(payload)}\n`);
+    const request = typeof payload === 'string' ? payload : JSON.stringify(payload);
+    helper.stdin.write(`${request}\n`);
     helperReader.once('line', line => {
       let response;
       try {
         response = JSON.parse(line);
+        response = Object.assign({ ok: !response.error }, response);
       } catch (e) {
-        response = { error: 'invalid response' };
+        response = { ok: false, error: 'invalid response' };
       }
       event.reply('helper-response', response);
     });

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -1,5 +1,22 @@
-const { contextBridge } = require('electron');
+const { contextBridge, ipcRenderer } = require('electron');
 
 contextBridge.exposeInMainWorld('electronAPI', {
   // Placeholder for future APIs
+});
+
+contextBridge.exposeInMainWorld('leaderpassAPI', {
+  call(method, params) {
+    return new Promise((resolve, reject) => {
+      ipcRenderer.once('helper-response', (_event, result) => {
+        if (result && result.ok) {
+          resolve(result);
+        } else {
+          reject(result);
+        }
+      });
+
+      const payload = JSON.stringify({ method, params });
+      ipcRenderer.send('helper-request', payload);
+    });
+  }
 });


### PR DESCRIPTION
## Summary
- expose `leaderpassAPI.call(method, params)` in preload to send JSON helper requests and return a promise
- forward JSON string requests in main process and wrap helper responses with an `ok` flag

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf0f11aa2c8321893dd54f1c9e222d