### PR TITLE
feat: basic react panel

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -41,6 +41,20 @@ app.whenReady().then(() => {
     });
   });
 
+  // Handle generic leaderpass actions invoked from the renderer.
+  ipcMain.handle('leaderpass-call', async (event, action) => {
+    if (action === 'context') {
+      // In a real application this would retrieve live context.
+      return { status: 'ok', message: 'connected' };
+    }
+    const msg = `Action ${action} invoked`;
+    // Forward message to renderer consoles.
+    BrowserWindow.getAllWindows().forEach(w =>
+      w.webContents.send('helper-message', msg)
+    );
+    return { status: 'ok' };
+  });
+
   createWindow();
 
   app.on('activate', () => {

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -1,5 +1,27 @@
-const { contextBridge } = require('electron');
+const { contextBridge, ipcRenderer } = require('electron');
 
+// Expose leaderpassAPI for invoking backend actions.
+contextBridge.exposeInMainWorld('leaderpassAPI', {
+  /**
+   * Call an action on the backend via IPC.
+   * @param {string} action - Action name to invoke.
+   * @returns {Promise<any>} Promise resolving with the response.
+   */
+  call(action) {
+    return ipcRenderer.invoke('leaderpass-call', action);
+  }
+});
+
+// Expose helper message subscription API.
 contextBridge.exposeInMainWorld('electronAPI', {
-  // Placeholder for future APIs
+  /**
+   * Subscribe to helper messages.
+   * @param {(message: string) => void} callback
+   * @returns {() => void} unsubscribe function
+   */
+  onHelperMessage(callback) {
+    const handler = (_event, message) => callback(message);
+    ipcRenderer.on('helper-message', handler);
+    return () => ipcRenderer.removeListener('helper-message', handler);
+  }
 });

--- a/electron/renderer/App.jsx
+++ b/electron/renderer/App.jsx
@@ -1,10 +1,62 @@
-import React from 'react';
-import { createRoot } from 'react-dom/client';
+const { useEffect, useState } = React;
 
 function App() {
-  return <h1>EditPanel</h1>;
+  const [connected, setConnected] = useState(false);
+  const [info, setInfo] = useState(null);
+  const [log, setLog] = useState([]);
+
+  // Load context information on mount
+  useEffect(() => {
+    let active = true;
+    window.leaderpassAPI
+      .call('context')
+      .then(ctx => {
+        if (active) {
+          setInfo(ctx);
+          setConnected(true);
+        }
+      })
+      .catch(() => setConnected(false));
+
+    // Subscribe to helper messages
+    const unsubscribe = window.electronAPI.onHelperMessage(message => {
+      setLog(prev => {
+        const next = [...prev, message];
+        return next.slice(-20);
+      });
+    });
+
+    return () => {
+      active = false;
+      unsubscribe && unsubscribe();
+    };
+  }, []);
+
+  const callAction = action => {
+    window.leaderpassAPI.call(action);
+  };
+
+  return (
+    <div>
+      <div>
+        <strong>Connection:</strong> {connected ? 'Connected' : 'Disconnected'}
+      </div>
+      <div>
+        <strong>Info:</strong>
+        <pre>{info ? JSON.stringify(info, null, 2) : '...'}</pre>
+      </div>
+      <div>
+        <button onClick={() => callAction('add_marker')}>Add Marker</button>
+        <button onClick={() => callAction('start_render')}>Start Render</button>
+        <button onClick={() => callAction('stop_render')}>Stop Render</button>
+      </div>
+      <div>
+        <h3>Log</h3>
+        <pre>{log.join('\n')}</pre>
+      </div>
+    </div>
+  );
 }
 
-const container = document.getElementById('root');
-const root = createRoot(container);
+const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(<App />);

--- a/electron/renderer/index.html
+++ b/electron/renderer/index.html
@@ -3,9 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <title>EditPanel</title>
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="./App.jsx"></script>
+    <script type="text/babel" src="./App.jsx" data-presets="react"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add React App with connection indicator, context info, control buttons, and log console
- expose IPC APIs for leaderpass calls and helper message subscription
- serve React via simple script tags without a bundler

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf0f19bb3883218d982df682d6a3b2