### PR TITLE
feat: track Resolve status

### DIFF
--- a/electron/preload.js
+++ b/electron/preload.js
@@ -1,18 +1,29 @@
 const { contextBridge, ipcRenderer } = require('electron');
 
-// Expose leaderpassAPI for invoking backend actions.
+// Expose API for invoking helper commands.
 contextBridge.exposeInMainWorld('leaderpassAPI', {
   /**
-   * Call an action on the backend via IPC.
-   * @param {string} action - Action name to invoke.
-   * @returns {Promise<any>} Promise resolving with the response.
+   * Send a command to the Resolve helper.
+   * @param {string} cmd - Command name.
+   * @param {object} [params] - Optional parameters.
+   * @returns {Promise<any>} Resolves with the helper response.
    */
-  call(action) {
-    return ipcRenderer.invoke('leaderpass-call', action);
+  call(cmd, params = {}) {
+    return new Promise((resolve, reject) => {
+      ipcRenderer.once('helper-response', (_event, result) => {
+        if (result && result.ok) {
+          resolve(result);
+        } else {
+          reject(result);
+        }
+      });
+
+      ipcRenderer.send('helper-request', { cmd, ...params });
+    });
   }
 });
 
-// Expose helper message subscription API.
+// Expose helper message and status subscription API.
 contextBridge.exposeInMainWorld('electronAPI', {
   /**
    * Subscribe to helper messages.
@@ -23,22 +34,17 @@ contextBridge.exposeInMainWorld('electronAPI', {
     const handler = (_event, message) => callback(message);
     ipcRenderer.on('helper-message', handler);
     return () => ipcRenderer.removeListener('helper-message', handler);
+  },
+
+  /**
+   * Subscribe to helper status updates.
+   * @param {(status: any) => void} callback
+   * @returns {() => void} unsubscribe function
+   */
+  onHelperStatus(callback) {
+    const handler = (_event, status) => callback(status);
+    ipcRenderer.on('helper-status', handler);
+    return () => ipcRenderer.removeListener('helper-status', handler);
   }
 });
 
-contextBridge.exposeInMainWorld('leaderpassAPI', {
-  call(method, params) {
-    return new Promise((resolve, reject) => {
-      ipcRenderer.once('helper-response', (_event, result) => {
-        if (result && result.ok) {
-          resolve(result);
-        } else {
-          reject(result);
-        }
-      });
-
-      const payload = JSON.stringify({ method, params });
-      ipcRenderer.send('helper-request', payload);
-    });
-  }
-});


### PR DESCRIPTION
## Summary
- stream status lines from helper to renderer and update UI
- monitor Resolve availability in helper and emit context on connect
- expose helper APIs in preload for status subscription

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf13fd79d083218cf0de25c10c528f