### PR TITLE
Fix stray catch block in main process

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -38,7 +38,8 @@ app.whenReady().then(() => {
   });
 
   helperReader.on('line', line => {
-          let message;
+    try {
+      let message;
       try {
         message = JSON.parse(line);
       } catch (e) {


### PR DESCRIPTION
## Summary
- fix unmatched catch block in main process helper output handler

## Testing
- `npm test`
- `node --check electron/main.js`
- `python -m py_compile helper/resolve_helper.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf19f0691c8321b733d9336ae7088c