### PR TITLE
Revamp panel UI with project header and task grid

### DIFF
--- a/electron/renderer/index.html
+++ b/electron/renderer/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <title>EditPanel</title>
+    <link rel="stylesheet" href="./styles.css" />
     <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
     <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>

--- a/electron/renderer/styles.css
+++ b/electron/renderer/styles.css
@@ -1,0 +1,59 @@
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+  background: #f5f5f5;
+}
+
+.app-container {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+header {
+  text-align: center;
+  padding: 1rem;
+  font-size: 1.5rem;
+}
+
+.button-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 1rem;
+  padding: 1rem;
+  justify-items: center;
+}
+
+.task-button {
+  width: 120px;
+  height: 120px;
+  border: none;
+  border-radius: 8px;
+  background: #fff;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: transform 0.1s ease-in-out;
+}
+
+.task-button:hover {
+  transform: scale(1.05);
+}
+
+.task-button .icon {
+  font-size: 2rem;
+  margin-bottom: 0.5rem;
+}
+
+.log {
+  background: #111;
+  color: #0f0;
+  font-family: monospace;
+  padding: 0.5rem;
+  overflow-y: auto;
+  flex-grow: 1;
+  white-space: pre-wrap;
+}


### PR DESCRIPTION
## Summary
- Consolidate connection status and project context into a single scrollable log
- Show current project name as a centered header
- Add grid of placeholder task buttons with hover animations and icons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf273e6d148321a25dd54b295aa8ad