### PR TITLE
feat: add manual resolve connection

### DIFF
--- a/electron/renderer/styles.css
+++ b/electron/renderer/styles.css
@@ -57,3 +57,24 @@ header {
   flex-grow: 1;
   white-space: pre-wrap;
 }
+
+.connect-container {
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+}
+
+.connect-button {
+  padding: 1rem 2rem;
+  font-size: 1.2rem;
+  border: none;
+  border-radius: 8px;
+  background: #007bff;
+  color: #fff;
+  cursor: pointer;
+}
+
+.connect-button:hover {
+  background: #0056b3;
+}


### PR DESCRIPTION
## Summary
- switch Resolve helper to manual connect with new `connect` command
- display a connect button when disconnected and hide task buttons until connected
- add styling for the new connect workflow

## Testing
- `npm test`
- `python -m py_compile helper/resolve_helper.py`


------
https://chatgpt.com/codex/tasks/task_e_68c027a899408321b56a2ada7affee0b