### PR TITLE
Add slideout console log tray with toggle

### DIFF
--- a/electron/renderer/App.jsx
+++ b/electron/renderer/App.jsx
@@ -4,6 +4,7 @@ function App() {
   const [project, setProject] = useState('');
   const [log, setLog] = useState([]);
   const [connected, setConnected] = useState(false);
+  const [showLog, setShowLog] = useState(false);
 
   const appendLog = msg => {
     setLog(prev => {
@@ -68,8 +69,16 @@ function App() {
               <span>New Project Bins</span>
             </button>
           </div>
-          <div className="log">
-            <pre>{log.join('\n')}</pre>
+          <button
+            className="log-toggle"
+            onClick={() => setShowLog(prev => !prev)}
+          >
+            {showLog ? 'Hide Log' : 'Show Log'}
+          </button>
+          <div className={`log-tray ${showLog ? 'open' : ''}`}>
+            <div className="log">
+              <pre>{log.join('\n')}</pre>
+            </div>
           </div>
         </>
       ) : (

--- a/electron/renderer/styles.css
+++ b/electron/renderer/styles.css
@@ -54,8 +54,41 @@ header {
   font-family: monospace;
   padding: 0.5rem;
   overflow-y: auto;
-  flex-grow: 1;
   white-space: pre-wrap;
+  height: 100%;
+}
+
+.log-tray {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  max-height: 40%;
+  transform: translateY(100%);
+  transition: transform 0.3s ease-in-out;
+  display: flex;
+  z-index: 999;
+}
+
+.log-tray.open {
+  transform: translateY(0);
+}
+
+.log-toggle {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 4px;
+  background: #007bff;
+  color: #fff;
+  cursor: pointer;
+  z-index: 1000;
+}
+
+.log-toggle:hover {
+  background: #0056b3;
 }
 
 .connect-container {


### PR DESCRIPTION
## Summary
- allow users to toggle visibility of the console log
- implement sliding tray for the log with simple animation
- style toggle button and tray for fixed positioning

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c028ff07788321850640b40716f81a