### PR TITLE
Add dashboard and slideout console

### DIFF
--- a/electron/renderer/App.jsx
+++ b/electron/renderer/App.jsx
@@ -2,6 +2,7 @@ const { useEffect, useState } = React;
 
 function App() {
   const [project, setProject] = useState('');
+  const [timeline, setTimeline] = useState('');
   const [log, setLog] = useState([]);
   const [connected, setConnected] = useState(false);
 
@@ -18,12 +19,18 @@ function App() {
       appendLog(msg);
       if (status.code === 'CONNECTED' && status.ok) {
         setConnected(true);
-        if (status.data && status.data.project) {
-          setProject(status.data.project);
+        if (status.data) {
+          if (status.data.project) {
+            setProject(status.data.project);
+          }
+          if (status.data.timeline) {
+            setTimeline(status.data.timeline);
+          }
         }
       } else {
         setConnected(false);
         setProject('');
+        setTimeline('');
       }
     });
 
@@ -54,7 +61,7 @@ function App() {
       <header>{project || 'No Project'}</header>
       {connected ? (
         <>
-          <div className="button-grid">
+          <div className="function-grid">
             <button className="task-button" onClick={() => logAction('Export')}>
               <span className="icon">📤</span>
               <span>Export</span>
@@ -68,8 +75,9 @@ function App() {
               <span>New Project Bins</span>
             </button>
           </div>
-          <div className="log">
-            <pre>{log.join('\n')}</pre>
+          <div className="dashboard">
+            <h2>Dashboard</h2>
+            <div>Active Timeline: {timeline || 'None'}</div>
           </div>
         </>
       ) : (
@@ -79,6 +87,7 @@ function App() {
           </button>
         </div>
       )}
+      <SlideoutConsole log={log} />
     </div>
   );
 }

--- a/electron/renderer/components/SlideoutConsole.jsx
+++ b/electron/renderer/components/SlideoutConsole.jsx
@@ -1,0 +1,17 @@
+const { useState } = React;
+
+function SlideoutConsole({ log }) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className={`slideout-console ${open ? 'open' : ''}`}>
+      <button className="toggle-button" onClick={() => setOpen(!open)}>
+        {open ? 'Hide Console' : 'Show Console'}
+      </button>
+      <div className="console-content">
+        <pre>{log.join('\n')}</pre>
+      </div>
+    </div>
+  );
+}
+

--- a/electron/renderer/index.html
+++ b/electron/renderer/index.html
@@ -10,6 +10,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <script type="text/babel" src="./components/SlideoutConsole.jsx" data-presets="react"></script>
     <script type="text/babel" src="./App.jsx" data-presets="react"></script>
   </body>
 </html>

--- a/electron/renderer/styles.css
+++ b/electron/renderer/styles.css
@@ -16,7 +16,7 @@ header {
   font-size: 1.5rem;
 }
 
-.button-grid {
+.function-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
   gap: 1rem;
@@ -48,14 +48,44 @@ header {
   margin-bottom: 0.5rem;
 }
 
-.log {
+
+.dashboard {
+  padding: 1rem;
+  margin: 0 1rem;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.slideout-console {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  transform: translateY(calc(100% - 30px));
+  transition: transform 0.3s ease-in-out;
+  font-family: monospace;
+}
+
+.slideout-console.open {
+  transform: translateY(0);
+}
+
+.slideout-console .toggle-button {
+  width: 100%;
+  height: 30px;
+  background: #222;
+  color: #0f0;
+  border: none;
+  cursor: pointer;
+}
+
+.slideout-console .console-content {
   background: #111;
   color: #0f0;
-  font-family: monospace;
-  padding: 0.5rem;
+  max-height: 200px;
   overflow-y: auto;
-  flex-grow: 1;
-  white-space: pre-wrap;
+  padding: 0.5rem;
 }
 
 .connect-container {


### PR DESCRIPTION
## Summary
- Capture active timeline status and display it in a new dashboard section
- Add a slide-out console component for viewing recent log entries
- Load new component and styles for function grid and console UI

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c02a8937b883219b33874dd6e6bdef