### PR TITLE
refactor: remove React hook destructuring

### DIFF
--- a/electron/renderer/App.jsx
+++ b/electron/renderer/App.jsx
@@ -1,11 +1,9 @@
-const { useEffect, useState } = React;
-
 function App() {
-  const [project, setProject] = useState('');
-  const [timeline, setTimeline] = useState('');
-  const [log, setLog] = useState([]);
-  const [connected, setConnected] = useState(false);
-  const [showLog, setShowLog] = useState(false);
+  const [project, setProject] = React.useState('');
+  const [timeline, setTimeline] = React.useState('');
+  const [log, setLog] = React.useState([]);
+  const [connected, setConnected] = React.useState(false);
+  const [showLog, setShowLog] = React.useState(false);
 
   const appendLog = msg => {
     setLog(prev => {
@@ -14,7 +12,7 @@ function App() {
     });
   };
 
-  useEffect(() => {
+  React.useEffect(() => {
     const unsubscribeStatus = window.electronAPI.onHelperStatus(status => {
       const msg = `Status: ${status.code}${status.error ? ' - ' + status.error : ''}`;
       appendLog(msg);

--- a/electron/renderer/components/SlideoutConsole.jsx
+++ b/electron/renderer/components/SlideoutConsole.jsx
@@ -1,7 +1,5 @@
-const { useState } = React;
-
 function SlideoutConsole({ log }) {
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = React.useState(false);
 
   return (
     <div className={`slideout-console ${open ? 'open' : ''}`}>


### PR DESCRIPTION
## Summary
- avoid polluting global scope by removing React hook destructuring
- reference hooks directly from the React object in renderer components

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c02e6c913c8321a3cb304fa355d918