### PR TITLE
Add project bin generator with logging

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -43,6 +43,13 @@ app.whenReady().then(() => {
         return;
       }
 
+      if (message.event === 'message') {
+        BrowserWindow.getAllWindows().forEach(w =>
+          w.webContents.send('helper-message', message.message || message.data)
+        );
+        return;
+      }
+
       if (pending.length) {
         const event = pending.shift();
         message = Object.assign({ ok: !message.error }, message);

--- a/electron/renderer/App.jsx
+++ b/electron/renderer/App.jsx
@@ -55,6 +55,14 @@ function App() {
       .catch(err => appendLog(`Connect error: ${err?.error || err}`));
   };
 
+  const handleNewProjectBins = () => {
+    appendLog('New Project Bins clicked');
+    window.leaderpassAPI
+      .call('create_project_bins')
+      .then(() => appendLog('Project bin creation command sent'))
+      .catch(err => appendLog(`Project bin creation error: ${err?.error || err}`));
+  };
+
   return (
     <div className="app-container">
       <header>{project || 'No Project'}</header>
@@ -69,7 +77,7 @@ function App() {
               <span className="icon">📝</span>
               <span>Spellcheck</span>
             </button>
-            <button className="task-button" onClick={() => logAction('New Project Bins')}>
+            <button className="task-button" onClick={handleNewProjectBins}>
               <span className="icon">🗂️</span>
               <span>New Project Bins</span>
             </button>


### PR DESCRIPTION
## Summary
- Add helper command to automatically create a standard project bin structure with detailed logging
- Forward helper log events to the renderer for real-time console updates
- Wire "New Project Bins" tile to invoke the new command and display logs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c03b9b1ac083219a904d479eb78ceb