### PR TITLE
Make helper module importable from project root

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -22,8 +22,9 @@ function createWindow() {
 }
 
 app.whenReady().then(() => {
-  helperProc = spawn('python', [path.join(__dirname, '..', 'helper', 'resolve_helper.py')], {
-    stdio: ['pipe', 'pipe', 'inherit']
+  helperProc = spawn('python', ['-m', 'helper.resolve_helper'], {
+    stdio: ['pipe', 'pipe', 'inherit'],
+    cwd: path.join(__dirname, '..')
   });
   helperReader = readline.createInterface({ input: helperProc.stdout });
 

--- a/helper/__init__.py
+++ b/helper/__init__.py
@@ -1,0 +1,1 @@
+"""Helper package for Resolve integration."""

--- a/helper/resolve_helper.py
+++ b/helper/resolve_helper.py
@@ -142,7 +142,7 @@ def _resp_err(req_id: Any, msg: str) -> Dict[str, Any]:
     return {"id": req_id, "ok": False, "data": None, "error": msg}
 
 
-from .commands import HANDLERS
+from helper.commands import HANDLERS
 
 # ---------- Main loop ----------
 def main() -> None:


### PR DESCRIPTION
## Summary
- mark helper directory as Python package
- use helper.commands for handler import
- spawn helper as `python -m helper.resolve_helper` from project root

## Testing
- `npm test`
- `python -m py_compile helper/resolve_helper.py helper/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68c04323bc2c8321a502daebc04e2888