### PR TITLE
feat: dark theme with bottom-anchored dashboard

### DIFF
--- a/electron/renderer/App.jsx
+++ b/electron/renderer/App.jsx
@@ -3,7 +3,7 @@ function App() {
   const [timeline, setTimeline] = React.useState('');
   const [log, setLog] = React.useState([]);
   const [connected, setConnected] = React.useState(false);
-  const [showLog, setShowLog] = React.useState(false);
+  const [consoleOpen, setConsoleOpen] = React.useState(false);
 
   const appendLog = msg => {
     setLog(prev => {
@@ -64,7 +64,7 @@ function App() {
   };
 
   return (
-    <div className="app-container">
+    <div className="app-container" style={{ paddingBottom: consoleOpen ? '230px' : '30px' }}>
       <header>{project || 'No Project'}</header>
       {connected ? (
         <>
@@ -94,7 +94,7 @@ function App() {
           </button>
         </div>
       )}
-      <SlideoutConsole log={log} />
+      <SlideoutConsole log={log} open={consoleOpen} onToggle={setConsoleOpen} />
     </div>
   );
 }

--- a/electron/renderer/components/SlideoutConsole.jsx
+++ b/electron/renderer/components/SlideoutConsole.jsx
@@ -1,9 +1,7 @@
-function SlideoutConsole({ log }) {
-  const [open, setOpen] = React.useState(false);
-
+function SlideoutConsole({ log, open, onToggle }) {
   return (
     <div className={`slideout-console ${open ? 'open' : ''}`}>
-      <button className="toggle-button" onClick={() => setOpen(!open)}>
+      <button className="toggle-button" onClick={() => onToggle(!open)}>
         {open ? 'Hide Console' : 'Show Console'}
       </button>
       <div className="console-content">

--- a/electron/renderer/styles.css
+++ b/electron/renderer/styles.css
@@ -1,7 +1,22 @@
+@font-face {
+  font-family: 'Metropolis';
+  src: url('./fonts/Metropolis-Regular.otf') format('opentype');
+  font-weight: 400;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'Metropolis';
+  src: url('./fonts/Metropolis-Bold.otf') format('opentype');
+  font-weight: 700;
+  font-style: normal;
+}
+
 body {
   margin: 0;
-  font-family: Arial, sans-serif;
-  background: #f5f5f5;
+  font-family: 'Metropolis', sans-serif;
+  background: #0d0d0d;
+  color: #fff;
 }
 
 .app-container {
@@ -14,6 +29,7 @@ header {
   text-align: center;
   padding: 1rem;
   font-size: 1.5rem;
+  border-bottom: 1px solid #d4af37;
 }
 
 .function-grid {
@@ -27,34 +43,35 @@ header {
 .task-button {
   width: 120px;
   height: 120px;
-  border: none;
+  border: 1px solid #d4af37;
   border-radius: 8px;
-  background: #fff;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  background: #1e1e1e;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  transition: transform 0.1s ease-in-out;
+  transition: background 0.1s ease-in-out;
 }
 
 .task-button:hover {
-  transform: scale(1.05);
+  background: #2a2a2a;
 }
 
 .task-button .icon {
   font-size: 2rem;
   margin-bottom: 0.5rem;
+  color: #fff;
 }
 
 
 .dashboard {
+  margin-top: auto;
   padding: 1rem;
   margin: 0 1rem;
-  background: #fff;
+  background: #1e1e1e;
+  border: 1px solid #d4af37;
   border-radius: 8px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
 }
 
 .slideout-console {
@@ -64,7 +81,7 @@ header {
   right: 0;
   transform: translateY(calc(100% - 30px));
   transition: transform 0.3s ease-in-out;
-  font-family: monospace;
+  font-family: 'Metropolis', monospace;
 }
 
 .slideout-console.open {
@@ -74,18 +91,19 @@ header {
 .slideout-console .toggle-button {
   width: 100%;
   height: 30px;
-  background: #222;
-  color: #0f0;
-  border: none;
+  background: #1e1e1e;
+  color: #fff;
+  border: 1px solid #d4af37;
   cursor: pointer;
 }
 
 .slideout-console .console-content {
-  background: #111;
-  color: #0f0;
+  background: #000;
+  color: #fff;
   max-height: 200px;
   overflow-y: auto;
   padding: 0.5rem;
+  border-top: 1px solid #d4af37;
 }
 
 .connect-container {
@@ -98,13 +116,13 @@ header {
 .connect-button {
   padding: 1rem 2rem;
   font-size: 1.2rem;
-  border: none;
+  border: 1px solid #d4af37;
   border-radius: 8px;
-  background: #007bff;
+  background: #1e1e1e;
   color: #fff;
   cursor: pointer;
 }
 
 .connect-button:hover {
-  background: #0056b3;
+  background: #2a2a2a;
 }


### PR DESCRIPTION
## Summary
- restyle renderer with dark theme, golden accents, and Metropolis fonts
- anchor dashboard to bottom and adjust for console height
- expose slide-out console state to parent for layout management

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c05732f4888321980771551689cc2d