### PR TITLE
Add category folders with action tiles

### DIFF
--- a/electron/renderer/App.jsx
+++ b/electron/renderer/App.jsx
@@ -4,6 +4,7 @@ function App() {
   const [log, setLog] = React.useState([]);
   const [connected, setConnected] = React.useState(false);
   const [consoleOpen, setConsoleOpen] = React.useState(false);
+  const [currentCategory, setCurrentCategory] = React.useState(null);
 
   const appendLog = msg => {
     setLog(prev => {
@@ -63,25 +64,62 @@ function App() {
       .catch(err => appendLog(`Project bin creation error: ${err?.error || err}`));
   };
 
+  const handleLPBaseExport = () => {
+    logAction('LP Base Export');
+    // Placeholder for LP Base Export script
+  };
+
+  const categories = ['SETUP', 'EDIT', 'AUDIO', 'DELIVER'];
+
+  const actions = {
+    SETUP: [
+      { label: 'New Project Bins', icon: '🗂️', onClick: handleNewProjectBins }
+    ],
+    EDIT: [
+      { label: 'Spellcheck', icon: '📝', onClick: () => logAction('Spellcheck') }
+    ],
+    AUDIO: [],
+    DELIVER: [
+      { label: 'LP Base Export', icon: '📤', onClick: handleLPBaseExport }
+    ]
+  };
+
   return (
     <div className="app-container" style={{ paddingBottom: consoleOpen ? '240px' : '40px' }}>
       <header>{project || 'No Project'}</header>
       {connected ? (
         <>
-          <div className="function-grid">
-            <button className="task-button" onClick={() => logAction('Export')}>
-              <span className="icon">📤</span>
-              <span>Export</span>
-            </button>
-            <button className="task-button" onClick={() => logAction('Spellcheck')}>
-              <span className="icon">📝</span>
-              <span>Spellcheck</span>
-            </button>
-            <button className="task-button" onClick={handleNewProjectBins}>
-              <span className="icon">🗂️</span>
-              <span>New Project Bins</span>
-            </button>
-          </div>
+          {currentCategory === null ? (
+            <div className="function-grid folder-grid">
+              {categories.map(cat => (
+                <button
+                  key={cat}
+                  className="folder-button"
+                  onClick={() => setCurrentCategory(cat)}
+                >
+                  {cat}
+                </button>
+              ))}
+            </div>
+          ) : (
+            <div className="category-view">
+              <button className="back-button" onClick={() => setCurrentCategory(null)}>
+                Back
+              </button>
+              <div className="function-grid">
+                {actions[currentCategory].map(action => (
+                  <button
+                    key={action.label}
+                    className="task-button"
+                    onClick={action.onClick}
+                  >
+                    <span className="icon">{action.icon}</span>
+                    <span>{action.label}</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
           <div className="dashboard">
             <h2>Dashboard</h2>
             <div>Active Timeline: {timeline || 'None'}</div>

--- a/electron/renderer/styles.css
+++ b/electron/renderer/styles.css
@@ -40,6 +40,10 @@ header {
   justify-items: center;
 }
 
+.folder-grid {
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+}
+
 
 .task-button {
   width: 120px;
@@ -65,6 +69,42 @@ header {
   font-size: 2rem;
   margin-bottom: 0.5rem;
   color: #fff;
+}
+
+.folder-button {
+  width: 160px;
+  height: 90px;
+  border: 1px solid #d4af37;
+  border-radius: 8px;
+  background: #1e1e1e;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: #fff;
+  font-weight: 700;
+  text-transform: uppercase;
+  transition: background 0.1s ease-in-out, transform 0.1s ease-in-out;
+}
+
+.folder-button:hover {
+  background: #2a2a2a;
+  transform: scale(1.05);
+}
+
+.back-button {
+  margin: 1rem;
+  padding: 0.5rem 1rem;
+  border: 1px solid #d4af37;
+  border-radius: 8px;
+  background: #1e1e1e;
+  color: #fff;
+  cursor: pointer;
+  text-transform: uppercase;
+}
+
+.back-button:hover {
+  background: #2a2a2a;
 }
 
 


### PR DESCRIPTION
## Summary
- Organize actions into categories (SETUP, EDIT, AUDIO, DELIVER)
- Provide navigation with a styled back button
- Add LP Base Export action and move existing actions into categories

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c05ddfccc483218ca411dae5be562c