### PR TITLE
Handle missing spellcheck dependencies gracefully

### DIFF
--- a/electron/renderer/App.jsx
+++ b/electron/renderer/App.jsx
@@ -97,13 +97,17 @@ function App() {
       appendLog('Leaderpass API not available; cannot run spellcheck');
       return;
     }
+    const misspell = window.spellcheckAPI?.misspellings;
+    if (!misspell) {
+      appendLog('Spellcheck API not available; using fallback');
+    }
     window.leaderpassAPI
       .call('spellcheck')
       .then(async res => {
         const items = (res.data && res.data.items) || [];
         const checked = [];
         for (const item of items) {
-          const misspelled = await window.spellcheckAPI.misspellings(item.text);
+          const misspelled = misspell ? await misspell(item.text) : [];
           checked.push({ ...item, misspelled });
         }
         setSpellReport(checked);


### PR DESCRIPTION
## Summary
- Wrap spellcheck requires in try/catch and fall back to no-op API if loading fails
- Warn when spellcheck dependencies are missing and expose empty misspellings method
- Safeguard renderer spellcheck handler against missing API

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1e2fd9a7083219901cd8b0ae6da16